### PR TITLE
hsn-job-id formatter should return integer

### DIFF
--- a/src/main/java/pl/nask/hsn2/jsontemplate/formatters/JobIdFormatter.java
+++ b/src/main/java/pl/nask/hsn2/jsontemplate/formatters/JobIdFormatter.java
@@ -28,10 +28,9 @@ public class JobIdFormatter implements IFormatter {
 	public Object format(Object value) {
 		if (value instanceof HsnContext) {
             HsnContext context = (HsnContext) value;
-            return "\"" + context.getJobId() + "\"";
+            return context.getJobId();
         } else {
             return value;
         }
 	}
-
 }


### PR DESCRIPTION
hsn-job-id returns string (e.g. "101") and not integer (e.g. 101).
