### PR TITLE
New formatter: hsn-object-id

### DIFF
--- a/src/main/java/jsontemplate/HsnFormatters.java
+++ b/src/main/java/jsontemplate/HsnFormatters.java
@@ -18,6 +18,7 @@
  */
 
 package jsontemplate;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,44 +32,43 @@ import pl.nask.hsn2.jsontemplate.formatters.JsStringFormatter;
 import pl.nask.hsn2.jsontemplate.formatters.JsonAttachment;
 import pl.nask.hsn2.jsontemplate.formatters.JsonFormatter;
 import pl.nask.hsn2.jsontemplate.formatters.NodeRefFormatter;
+import pl.nask.hsn2.jsontemplate.formatters.ObjectIdFormatter;
 import pl.nask.hsn2.jsontemplate.formatters.RelatedFilesFormatter;
-
 
 public final class HsnFormatters implements IFormatterResolver {
 
-    private static final ConcurrentMap<String, IFormatter> FORMATTERS = new ConcurrentHashMap<String, IFormatter>();
+	private static final ConcurrentMap<String, IFormatter> FORMATTERS = new ConcurrentHashMap<String, IFormatter>();
 
-    private static ObjectStoreConnector osConnector;
-    static {
-        FORMATTERS.put("json", new JsonFormatter());
-        FORMATTERS.put("js-string", new JsStringFormatter());
-        FORMATTERS.put("hsn-node-ref", new NodeRefFormatter());
-        FORMATTERS.put("hsn-job-id", new JobIdFormatter());
-        FORMATTERS.put("hsn-related-files", new RelatedFilesFormatter(osConnector));
-    }
+	private static ObjectStoreConnector osConnector;
+	static {
+		FORMATTERS.put("json", new JsonFormatter());
+		FORMATTERS.put("js-string", new JsStringFormatter());
+		FORMATTERS.put("hsn-node-ref", new NodeRefFormatter());
+		FORMATTERS.put("hsn-job-id", new JobIdFormatter());
+		FORMATTERS.put("hsn-object-id", new ObjectIdFormatter());
+		FORMATTERS.put("hsn-related-files", new RelatedFilesFormatter(osConnector));
+	}
 
-    private Map<String, IFormatter> contextFormatters = new HashMap<String, IFormatter>();
+	private Map<String, IFormatter> contextFormatters = new HashMap<String, IFormatter>();
 
-    public static void setOsConnector(ObjectStoreConnector osConnector) {
-        HsnFormatters.osConnector = osConnector;
-    }
+	public static void setOsConnector(ObjectStoreConnector osConnector) {
+		HsnFormatters.osConnector = osConnector;
+	}
 
-    public HsnFormatters(List<JsonAttachment> attachments) {
-        contextFormatters.put("hsn-attachment", new AttachmentFormatter(attachments));
-    }
+	public HsnFormatters(List<JsonAttachment> attachments) {
+		contextFormatters.put("hsn-attachment", new AttachmentFormatter(attachments));
+	}
 
-    public static IFormatterResolver getInstance(List<JsonAttachment> attachments) {
-        return new HsnFormatters(attachments);
-    }
+	public static IFormatterResolver getInstance(List<JsonAttachment> attachments) {
+		return new HsnFormatters(attachments);
+	}
 
-    @Override
-    public IFormatter getFormatter(String formatterName) {
-        IFormatter f = contextFormatters.get(formatterName);
-        if (f == null) {
-            f = FORMATTERS.get(formatterName);
-        }
-
-        return f;
-    }
-
+	@Override
+	public IFormatter getFormatter(String formatterName) {
+		IFormatter f = contextFormatters.get(formatterName);
+		if (f == null) {
+			f = FORMATTERS.get(formatterName);
+		}
+		return f;
+	}
 }

--- a/src/main/java/pl/nask/hsn2/jsontemplate/formatters/ObjectIdFormatter.java
+++ b/src/main/java/pl/nask/hsn2/jsontemplate/formatters/ObjectIdFormatter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) NASK, NCSC
+ * 
+ * This file is part of HoneySpider Network 2.0.
+ * 
+ * This is a free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.nask.hsn2.jsontemplate.formatters;
+
+import jsontemplate.IFormatter;
+import pl.nask.hsn2.wrappers.HsnContext;
+
+public class ObjectIdFormatter implements IFormatter {
+
+	@Override
+	public Object format(Object value) {
+		if (value instanceof HsnContext) {
+			HsnContext context = (HsnContext) value;
+			return context.getObjectId();
+		} else {
+			return value;
+		}
+	}
+}

--- a/src/test/java/pl/nask/hsn2/jsontemplate/formatters/JobIdAndObjectIdFormatterTest.java
+++ b/src/test/java/pl/nask/hsn2/jsontemplate/formatters/JobIdAndObjectIdFormatterTest.java
@@ -1,0 +1,67 @@
+package pl.nask.hsn2.jsontemplate.formatters;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import pl.nask.hsn2.wrappers.HsnContext;
+
+public class JobIdAndObjectIdFormatterTest {
+	private static final String TEST_STRING = "test string";
+
+	private static class TestContext implements HsnContext {
+		@Override
+		public long getObjectId() {
+			return 1;
+		}
+
+		@Override
+		public long getJobId() {
+			return 2;
+		}
+	}
+
+	private static final JobIdFormatter JOB_ID_FORMATTER = new JobIdFormatter();
+	private static final ObjectIdFormatter OBJ_ID_FORMATTER = new ObjectIdFormatter();
+
+	@Test
+	public void jobIdFormatterWithHsnContext() {
+		TestContext testContext = new TestContext();
+		Object result = JOB_ID_FORMATTER.format(testContext);
+		Assert.assertEquals(result instanceof Long, true);
+		Assert.assertEquals((long) result, 2);
+
+		String testString = TEST_STRING;
+		result = JOB_ID_FORMATTER.format(testString);
+		Assert.assertSame(result, testString);
+	}
+
+	@Test
+	public void jobIdFormatterWithNonHsnContext() {
+		StringBuilder builder = new StringBuilder(TEST_STRING);
+		Object result = JOB_ID_FORMATTER.format(builder);
+
+		Assert.assertSame(result, builder);
+		Assert.assertEquals(builder.toString(), TEST_STRING);
+	}
+
+	@Test
+	public void objectIdFormatterWithHsnContext() {
+		TestContext testContext = new TestContext();
+		Object result = OBJ_ID_FORMATTER.format(testContext);
+		Assert.assertEquals(result instanceof Long, true);
+		Assert.assertEquals((long) result, 1);
+
+		String testString = TEST_STRING;
+		result = JOB_ID_FORMATTER.format(testString);
+		Assert.assertSame(result, testString);
+	}
+
+	@Test
+	public void objectIdFormatterWithNonHsnContext() {
+		StringBuilder builder = new StringBuilder(TEST_STRING);
+		Object result = OBJ_ID_FORMATTER.format(builder);
+
+		Assert.assertSame(result, builder);
+		Assert.assertEquals(builder.toString(), TEST_STRING);
+	}
+}


### PR DESCRIPTION
It would greatly reduce the need for parsing documents in CouchDB if there was a "hsn-object-id" formatter, which would return object ID as an integer.
