### PR TITLE
wrong structure type in rb-pdffox template

### DIFF
--- a/src/main/java/pl/nask/hsn2/jsontemplate/formatters/JsStringFormatter.java
+++ b/src/main/java/pl/nask/hsn2/jsontemplate/formatters/JsStringFormatter.java
@@ -28,7 +28,15 @@ public class JsStringFormatter implements IFormatter {
 	@Override
 	public Object format(Object value) {
 		String jsonString = JSONValue.toJSONString(value);
-		return escapeSlashAndUnicode(jsonString);
+		String result = escapeSlashAndUnicode(jsonString);
+
+		// If value is Number result will be JSON number, which means no quotation marks. Return value has to be JSON
+		// text, so it have to be enclosed within quotation marks.
+		if (!result.startsWith("\"")) {
+			result = "\"" + result + "\"";
+		}
+
+		return result;
 	}
 
 	// This code was taken from org.apache.commons.jexl2.parser.StringParser (org.apache.commons-jexl:2.0.1) and

--- a/src/test/java/pl/nask/hsn2/jsontemplate/formatters/JsStringFormatterTest.java
+++ b/src/test/java/pl/nask/hsn2/jsontemplate/formatters/JsStringFormatterTest.java
@@ -102,4 +102,15 @@ public class JsStringFormatterTest {
 	public final void formatLowUnicode() {
 		Assert.assertEquals(FORMATTER.format(LOW_UNICODE), "\"\\\\u0099\"");
 	}
+
+	/**
+	 * Formatter has to return text value. All numbers has to be enclosed within quotation marks.
+	 */
+	@Test
+	public final void formatNumber() {
+		Assert.assertEquals(FORMATTER.format("abc"), "\"abc\"");
+		Assert.assertEquals(FORMATTER.format(11), "\"11\"");
+		Assert.assertEquals(FORMATTER.format(12d), "\"12.0\"");
+		Assert.assertEquals(FORMATTER.format(Long.valueOf(13)), "\"13\"");
+	}
 }


### PR DESCRIPTION
structure for 'return value' is set to 'text' but returns an integer
example can be found in attached image 
![rb-pdffox-reporter](https://f.cloud.github.com/assets/635861/333660/cbbef4e8-9c5d-11e2-9062-44d643c7e22e.png)
